### PR TITLE
Added optional batch handling of mutations inside single transaction

### DIFF
--- a/mypipe-api/src/main/scala/mypipe/api/Conf.scala
+++ b/mypipe-api/src/main/scala/mypipe/api/Conf.scala
@@ -20,6 +20,7 @@ object Conf {
   val FLUSH_INTERVAL_SECS = conf.getInt("mypipe.flush-interval-seconds")
 
   val GROUP_EVENTS_BY_TX = conf.getBoolean("mypipe.group-events-by-tx")
+  val GROUP_MUTATIONS_BY_TX = conf.getBoolean("mypipe.group-mutations-by-tx")
 
   val QUIT_ON_LISTENER_FAILURE = conf.getBoolean("mypipe.error.quit-on-listener-failure")
   val QUIT_ON_EVENT_DECODE_FAILURE = conf.getBoolean("mypipe.error.quit-on-event-decode-failure")

--- a/mypipe-api/src/main/scala/mypipe/mysql/binaryLogConsumerTraits.scala
+++ b/mypipe-api/src/main/scala/mypipe/mysql/binaryLogConsumerTraits.scala
@@ -18,6 +18,9 @@ trait ConfigBasedErrorHandlingBehaviour[BinaryLogEvent, BinaryLogPosition] exten
   def handleMutationError(listeners: List[BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition]], listener: BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition])(mutation: Mutation): Boolean =
     handler.exists(_.handleMutationError(listeners, listener)(mutation))
 
+  def handleMutationsError(listeners: List[BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition]], listener: BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition])(mutations: Seq[Mutation]): Boolean =
+    handler.exists(_.handleMutationsError(listeners, listener)(mutations))
+
   def handleTableMapError(listeners: List[BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition]], listener: BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition])(table: Table, event: TableMapEvent): Boolean =
     handler.exists(_.handleTableMapError(listeners, listener)(table, event))
 
@@ -49,6 +52,11 @@ class ConfigBasedErrorHandler[BinaryLogEvent, BinaryLogPosition] extends BinaryL
 
   override def handleMutationError(listeners: List[BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition]], listener: BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition])(mutation: Mutation): Boolean = {
     log.error("Could not handle mutation {} from listener {}", mutation.asInstanceOf[Any], listener)
+    !quitOnEventListenerFailure
+  }
+
+  override def handleMutationsError(listeners: List[BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition]], listener: BinaryLogConsumerListener[BinaryLogEvent, BinaryLogPosition])(mutations: Seq[Mutation]): Boolean = {
+    log.error("Could not handle {} mutation(s) from listener {}", mutations.length, listener)
     !quitOnEventListenerFailure
   }
 


### PR DESCRIPTION
By default, all mutations are processed with calling individual
onMutation handler. By enabling configuration flag mypipe.group-mutations-by-tx
you can force mypipe to call onMutation with a sequence of mutations
instead. In case of failure newly added handleMutationsError is called

Fixes #17
