### PR TITLE
MySQLMetadataManager: disconnect from all databases when actor stops

### DIFF
--- a/mypipe-api/src/main/scala/mypipe/mysql/MySQLMetadataManager.scala
+++ b/mypipe-api/src/main/scala/mypipe/mysql/MySQLMetadataManager.scala
@@ -37,6 +37,24 @@ class MySQLMetadataManager(hostname: String, port: Int, username: String, passwo
     case GetColumns(db, table, flushCache) ⇒ sender ! getTableColumns(db, table, flushCache)
   }
 
+  protected def disconnectAll(): Unit = {
+    for {
+      (_, connections) ← dbConns
+      connection ← connections
+    } connection.disconnect
+    dbConns.clear()
+  }
+
+  override def postStop(): Unit = {
+    disconnectAll()
+    super.postStop()
+  }
+
+  override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
+    disconnectAll()
+    super.preRestart(reason, message)
+  }
+
   protected def getTableColumns(db: String, table: String, flushCache: Boolean): (List[ColumnMetadata], Option[PrimaryKey]) = {
 
     if (flushCache) dbTableCols.remove(s"$db.$table")


### PR DESCRIPTION
Right now there is no way to kill connections that are used to retrieve table data - even killing the actor with `PoisonPill` does not help. I've added lines which close connections when actor dies. Note that it's done even in case of actor restart, because after restart a new instance of class is created and we will lose these connections anyway. 
