### PR TITLE
[api] use 'package' instead of 'package object'

### DIFF
--- a/mypipe-api/src/main/scala/mypipe/api/data/package.scala
+++ b/mypipe-api/src/main/scala/mypipe/api/data/package.scala
@@ -2,7 +2,7 @@ package mypipe.api
 
 import java.lang.{ Long ⇒ JLong }
 
-package object data {
+package data {
   case class PrimaryKey(columns: List[ColumnMetadata])
 
   case class ColumnMetadata(name: String, colType: ColumnType.EnumVal, isPrimaryKey: Boolean)

--- a/mypipe-api/src/main/scala/mypipe/api/event/package.scala
+++ b/mypipe-api/src/main/scala/mypipe/api/event/package.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import mypipe.api.data.{ Row, Table }
 
-package object event {
+package event {
 
   sealed abstract class Event
 


### PR DESCRIPTION
The 'package object' is afaik not needed here and leads to problems when implementing a Java Producer class. If this is not the case, please let me understand why using a 'package object' is needed and how it should work with a Java Producer as I'm still a Scala newbie ;)
