### PR TITLE
Write binlog event timestamps to mypipe Events.

### DIFF
--- a/mypipe-api/src/test/scala/mypipe/TableCacheSpec.scala
+++ b/mypipe-api/src/test/scala/mypipe/TableCacheSpec.scala
@@ -80,7 +80,7 @@ class TableCacheSpec extends UnitSpec with DatabaseSpec with ActorSystemSpec wit
       Await.result(insertFuture, 2000.millis)
 
       val table = queueTableMap.poll(10, TimeUnit.SECONDS)
-      tableCache.addTableByEvent(TableMapEvent(Long.unbox(table.id), table.name, table.db, table.columns.map(_.colType.value.toByte).toArray))
+      tableCache.addTableByEvent(TableMapEvent(0, Long.unbox(table.id), table.name, table.db, table.columns.map(_.colType.value.toByte).toArray))
       val table2 = tableCache.getTable(table.id)
       assert(table2.isDefined)
       assert(table2.get.name == Queries.TABLE.name)

--- a/mypipe-snapshotter/src/main/scala/mypipe/snapshotter/SelectConsumer.scala
+++ b/mypipe-snapshotter/src/main/scala/mypipe/snapshotter/SelectConsumer.scala
@@ -56,7 +56,7 @@ class SelectConsumer(override val config: Config)
     getTable(event.database, event.table) match {
       case Some(table) ⇒
         val rows = createRows(table, rowData)
-        Some(InsertMutation(table, rows))
+        Some(InsertMutation(0L, table, rows))
       case None ⇒
         log.error(s"Could not find table for event, skipping: $event")
         None


### PR DESCRIPTION
This change basically adds a timestamp field to every Event in mypipe,
and populates this field from the Event.getTimestamp of
binlog-connector.

When mutation events are grouped by transaction, they are treated
differently - all events in a transaction receive the timestamp of the
commit event.
